### PR TITLE
Fix error in head for twitter card and linkedin thumbnail

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,7 +16,7 @@
 	<meta property="og:title" content="The Buildings and Habitats Object Model"/>
 	<meta property="og:description" content="A collaborative computational development project and collective experiment. 
 	By sharing and co-creating code we can better shape our environment and our future."/>
-	<meta property="og:image" content="{{ site.url | append:'assets/images/bhom_pictogram_coral.png' }}"/>
+	<meta property="og:image" content="{{ site.url | append:'/assets/images/bhom_pictogram_coral.png' }}"/>
 	<meta property="og:image:type" content="image/png"/>
 	<meta property="og:image:height" content="2600"/>
 	<meta property="og:image:width" content="2600"/>


### PR DESCRIPTION
A missing `/` is creating issues with the thumbnail display in linkedin and twitter. 
The url was not created correctly `https://bhom.xyzassets/images/bhom_pictogram_coral.png`