### PR TITLE
Referencing samples links to release_2.1 branch

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -39,7 +39,7 @@
 
 		<div class="col col-2-of-12 col-m-4-of-4 center">
 			<p style="margin-top: 0px;"><a class="noborder" href="https://bhom.slack.com/join/shared_invite/enQtNTE3NTM0NTkxMDc0LWYyZDMwZTA4MDg1ZDk2NmE3OGZlNzNhNzk2M2M2OTI0NmE2MGJkOTdjNTI3MGNiZTBmYTFiOGU5ZjZjZGIxMzg"><span class="fab fa-slack-hash"></span>Questions? Ask on Slack!</a></p>
-			<p><a class="noborder" href="https://github.com/BHoM/samples"><span class="fas fa-vial"></span>Hack? Get samples!</a></p>
+			<p><a class="noborder" href="https://github.com/BHoM/samples/tree/release_2.1"><span class="fas fa-vial"></span>Hack? Get samples!</a></p>
 			<p><a class="noborder" href="https://github.com/BHoM/documentation/wiki"><span class="fab fa-wikipedia-w"></span>Read the Wiki!</a></p>
 			<hr>
 			<p><a class="noborder" href="https://github.com/BHoM"><span class="fas fa-terminal"></span>  Get code on GitHub</a></p>

--- a/_includes/what.html
+++ b/_includes/what.html
@@ -30,7 +30,7 @@
 					</p>
 					<ul>
 						<li>
-							<a href="https://github.com/BHoM/samples/tree/master/Structural_Adapters/Interop Revit Robot ETABS">
+							<a href="https://github.com/BHoM/samples/tree/release_2.1/Structural_Adapters/Interop%20Revit%20Robot%20ETABS">
 								<span class="fas fa-vial"></span>Try the sample script!
 							</a>
 						</li>
@@ -99,7 +99,7 @@
 					</p>
 					<ul>
 						<li>
-							<a href="https://github.com/BHoM/samples/tree/master/oM/CustomObjects Grasshopper">
+							<a href="https://github.com/BHoM/samples/tree/release_2.1/oM/CustomObjects%20Grasshopper">
 								<span class="fas fa-vial"></span> Try the sample script!
 							</a>
 						</li>


### PR DESCRIPTION
### Issues addressed by this PR

Closes #13 

As discussed @epignatelli @IsakNaslundBh - repointing website links to the latest release branch of samples rather than the master
