### PR TITLE
bhom.github.io - Issue 23 - capture installer downloads

### DIFF
--- a/pages/installer.html
+++ b/pages/installer.html
@@ -7,8 +7,8 @@ permalink: /installer/
 
 	<script>
 		(function redirect() {
-			gtag('event', 'download', {'transport': 'beacon', 'event_action': 'click', 'event_category': 'download', 'event_label': 'installer'});
-			gtag('event', 'page_view', {'transport': 'beacon'});
+			gtag('event', 'download', {'transport_type': 'beacon', 'event_action': 'click', 'event_category': 'download', 'event_label': 'installer'});
+			gtag('event', 'page_view', {'transport_type': 'beacon'});
 			window.location = "https://bhom.xyz/assets/installers/BHoM_v2.2.beta.0.exe";
 			setTimeout(function(){
 				window.location = "https://github.com/BHoM/documentation/wiki";

--- a/pages/installer.html
+++ b/pages/installer.html
@@ -2,14 +2,20 @@
 permalink: /installer/
 ---
 <head>
+	
+	{% include analytics.html %}
+
 	<script>
 		(function redirect() {
+			gtag('event', 'download', {'transport': 'beacon', 'event_action': 'click', 'event_category': 'download', 'event_label': 'installer'});
+			gtag('event', 'page_view', {'transport': 'beacon'});
 			window.location = "https://bhom.xyz/assets/installers/BHoM_v2.2.beta.0.exe";
 			setTimeout(function(){
 				window.location = "https://github.com/BHoM/documentation/wiki";
 			}, 500);
 		})();
 	</script>
+
 </head>
 <body>
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED --> 
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #23
<!-- Add short description of what has been fixed -->
To have and idea of how many versions of the BHoM are out there, and better target the deprecation/remove of methods.
Adding support to capture events via google tag manager. Events are pushed straight to Google Analytics.
