### PR TITLE
Updating installer hyperlink to refer to 2.4

### DIFF
--- a/_includes/why.html
+++ b/_includes/why.html
@@ -37,7 +37,7 @@
 					<a class="button-link noborder" href="https://github.com/BHoM"><span class="fab fa-github x2"></span>View on GitHub</a>
 				</div>
 				<div class="col right">
-					<a class="button-link noborder" href="{{ "installer" | relative_url }}"><span class="fas fa-arrow-down x2"></span><span class="new">New!</span> 2.3.β.0 installer</a></button>
+					<a class="button-link noborder" href="{{ "installer" | relative_url }}"><span class="fas fa-arrow-down x2"></span><span class="new">New!</span> 2.4.β.0 installer</a></button>
 				</div>
 			</div>
 			<div class="row s-and-lower">
@@ -45,7 +45,7 @@
 					<a class="button-link noborder" href="https://github.com/BHoM"><span class="fab fa-github x2"></span>View on GitHub</a>
 				</div>
 				<div class="col s-and-lower left">
-					<a class=" button-link noborder" href="{{ "installer" | relative_url }}"><span class="fas fa-arrow-down x2"></span><span class="new">New 2.3.β.0 installer!</span></a>
+					<a class=" button-link noborder" href="{{ "installer" | relative_url }}"><span class="fas fa-arrow-down x2"></span><span class="new">New 2.4.β.0 installer!</span></a>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #27 

<!-- Add short description of what has been fixed -->


### Additional comments

@FraserGreenroyd - was thinking of removing the "New" prefix to the installer hyperlink also - as there is always a "New" installer coming down the line every few months.
Perhaps lets revisit that strategy.
Decided not to remove now to avoid confusing this issue further. 😃 
But let's plan to remove mid quarter, at least.