### PR TITLE
Update website link

### DIFF
--- a/_includes/why.html
+++ b/_includes/why.html
@@ -37,7 +37,7 @@
 					<a class="button-link noborder" href="https://github.com/BHoM"><span class="fab fa-github x2"></span>View on GitHub</a>
 				</div>
 				<div class="col right">
-					<a class="button-link noborder" href="{{ "installer" | relative_url }}"><span class="fas fa-arrow-down x2"></span><span class="new">New!</span> 2.4.β.1 installer</a></button>
+					<a class="button-link noborder" href="{{ "installer" | relative_url }}"><span class="fas fa-arrow-down x2"></span><!--<span class="new">New!</span>--> Download the 2.4.β.1 installer</a></button>
 				</div>
 			</div>
 			<div class="row s-and-lower">
@@ -45,7 +45,7 @@
 					<a class="button-link noborder" href="https://github.com/BHoM"><span class="fab fa-github x2"></span>View on GitHub</a>
 				</div>
 				<div class="col s-and-lower left">
-					<a class=" button-link noborder" href="{{ "installer" | relative_url }}"><span class="fas fa-arrow-down x2"></span><span class="new">New 2.4.β.1 installer!</span></a>
+					<a class=" button-link noborder" href="{{ "installer" | relative_url }}"><span class="fas fa-arrow-down x2"></span><!--<span class="new">New--> <span>Download the 2.4.β.1 installer!</span></a>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #31 


### Test files
N/A


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
Removes the `new` keyword on the installer link and replaces it with a `Download` action instead - see issue #31 and PR #30 for more details.

Existing code saying `new` is kept in commented out style ready for the 3.0 release when the `new` span will be relevant again :smile: